### PR TITLE
Python3.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Steady Mark
-> version 0.4.5
+> version 0.4.6
 [![Build Status](https://secure.travis-ci.org/gabrielfalcao/steadymark.png?branch=master)](http://travis-ci.org/#!/gabrielfalcao/steadymark)
 
 ![meme](http://cdn.memegenerator.net/instances/400x/24908847.jpg)
@@ -64,10 +64,10 @@ Just run with:
 $ steadymark README.md
 ```
 
-# Steadymark is on version 0.4.5
+# Steadymark is on version 0.4.6
 
 ```python
 >>> from sure import expect
 >>> from steadymark import version
->>> assert expect(version).should.equal("0.4.5")
+>>> assert expect(version).should.equal("0.4.6")
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ it will be used as title for your test.
 
 ```python
 from sure import expect
-assert expect(u"Gabriel Falcao".lower()).equals(u"gabriel falcao")
+assert expect("Gabriel Falcao".lower()).equals("gabriel falcao")
 ```
 
 ## python can add numbers

--- a/requirements.pip
+++ b/requirements.pip
@@ -5,5 +5,5 @@ ipdb==0.7
 ipython==0.13
 misaka==1.0.2
 nose==1.1.2
-sure==1.1.7
+git+git://github.com/grigi/sure.git@master#egg=sure == 1.2.3
 tox==1.4.2

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ if not PY3:
 
 setup(name='steadymark',
     version=version,
-    description=(u'Markdown-based test runner for python. '
+    description=('Markdown-based test runner for python. '
                  'Good for github projects'),
-    author=u'Gabriel Falcao',
+    author='Gabriel Falcao',
     author_email='gabriel@nacaolivre.org',
     url='http://github.com/gabrielfalcao/steadymark',
     packages=get_packages(),

--- a/steadymark/core.py
+++ b/steadymark/core.py
@@ -138,10 +138,10 @@ class SteadyMark(BaseRenderer):
             item = self._tests[-1]
 
         else:
-            item[u'code'] = text_type(code).strip()
+            item['code'] = text_type(code).strip()
 
         if 'title' not in item:
-            item[u'title'] = u'Test #{0}'.format(len(self._tests))
+            item['title'] = 'Test #{0}'.format(len(self._tests))
             self._tests.append({})
 
     def header(self, title, level):
@@ -149,8 +149,8 @@ class SteadyMark(BaseRenderer):
         t = re.sub(r'^[# ]*(.*)', '\g<1>', t)
         t = re.sub(r'`([^`]*)`', '\033[1;33m\g<1>\033[0m', t)
         self._tests.append({
-            u'title': t,
-            u'level': int(level),
+            'title': t,
+            'level': int(level),
         })
 
     def postprocess(self, full_document):

--- a/steadymark/runner.py
+++ b/steadymark/runner.py
@@ -47,7 +47,7 @@ if not PY3:
 
 
 class Runner(object):
-    def __init__(self, filename=None, text=u''):
+    def __init__(self, filename=None, text=''):
         if filename and not os.path.exists(filename):
             print('steadymark could not find {0}'.format(filename))
             sys.exit(1)
@@ -62,8 +62,8 @@ class Runner(object):
 
     def print_white(self, text, indentation=0):
         white = {
-            True: u'\033[1;37m',
-            False: u'',
+            True: '\033[1;37m',
+            False: '',
         }
         for line in text.splitlines():
             print("{1}{2}{0}\033[0m".format(
@@ -79,10 +79,10 @@ class Runner(object):
             return super(Runner, self).__getattribute__(attr)
 
         color_for = {
-            'print_white': u'\033[1;37m',
-            'print_red': u'\033[1;31m',
-            'print_green': u'\033[1;32m',
-            'print_yellow': u'\033[1;33m',
+            'print_white': '\033[1;37m',
+            'print_red': '\033[1;31m',
+            'print_green': '\033[1;32m',
+            'print_yellow': '\033[1;33m',
         }
         ansi = color_for[attr]
         if SUPPORTS_ANSI:
@@ -112,17 +112,17 @@ class Runner(object):
         # if 'None' == formatted_tb:
         formatted_tb = ''.join(traceback.format_tb(tb))
         formatted_tb = formatted_tb.replace(
-            u'File "{0}"'.format(test.title),
-            u'In the test "{0}"'.format(test.title),
+            'File "{0}"'.format(test.title),
+            'In the test "{0}"'.format(test.title),
         )
         formatted_tb = formatted_tb.replace(
-            u'@STEADYMARK@', text_type(test.title))
+            '@STEADYMARK@', text_type(test.title))
 
         if SUPPORTS_ANSI:
             color = '\033[1;36m'
         else:
             color = ''
-        return u'{0} {3}{1}\n{2}\n'.format(
+        return '{0} {3}{1}\n{2}\n'.format(
             exc.__name__,
             exc_instance,
             formatted_tb,
@@ -138,7 +138,7 @@ class Runner(object):
         exc_type, exc_val, exc_tb = failure
 
         if exc_type is DocTestFailure:
-            formatted_tb = u"the line {0}: {1}\n".format(
+            formatted_tb = "the line {0}: {1}\n".format(
                 exc_val.example.lineno,
                 exc_val.example.source,
             )

--- a/steadymark/version.py
+++ b/steadymark/version.py
@@ -25,4 +25,4 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import unicode_literals
 
-version = '0.4.5'
+version = '0.4.6'

--- a/tests/integration/test_exit_status.py
+++ b/tests/integration/test_exit_status.py
@@ -42,7 +42,7 @@ def run(path):
 
 
 def test_failure_exits_with_1():
-    (u"SteadyMark should exit with status 1 in case of failure")
+    ("SteadyMark should exit with status 1 in case of failure")
 
     path = join(CURDIR, 'fails.md')
     run.when.called_with(path).should.throw(
@@ -50,7 +50,7 @@ def test_failure_exits_with_1():
 
 
 def test_success_exits_with_0():
-    (u"SteadyMark should exit with status 0 in case of success")
+    ("SteadyMark should exit with status 0 in case of success")
 
     status = run(join(CURDIR, 'passes.md'))
     status.should.equal(0)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -30,10 +30,10 @@ from steadymark.core import SteadyMark
 
 
 def test_find_python_code_with_titles():
-    (u"SteadyMark should find python code and use the "
+    ("SteadyMark should find python code and use the "
      "previous header as title")
 
-    md = u"""# test 1
+    md = """# test 1
 a paragraph
 
 ```python
@@ -75,10 +75,10 @@ assert False, 'uh yeah'
 
 
 def test_find_inline_doctests_with_titles():
-    (u"SteadyMark should find docstrings and use the "
+    ("SteadyMark should find docstrings and use the "
      "previous header as title")
 
-    md = u"""# test 1
+    md = """# test 1
 a paragraph
 
 ```python
@@ -125,9 +125,9 @@ assert False, 'uh yeah'
 
 
 def test_use_same_title_for_all_tests():
-    (u"SteadyMark should find all the tests under the same header (title)")
+    ("SteadyMark should find all the tests under the same header (title)")
 
-    md = u"""# Test Foo
+    md = """# Test Foo
 a paragraph
 
 ```python
@@ -161,9 +161,9 @@ assert False, 'THIRD'
 
 
 def test_skip_tests_marked_with_ignore():
-    (u"SteadyMark should skip tests with the 'ignore' modeline")
+    ("SteadyMark should skip tests with the 'ignore' modeline")
 
-    md = u"""# My test
+    md = """# My test
 ```python
 # steadymark: ignore
 This should break, but it won't because steady mark will ignore this

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -30,10 +30,10 @@ from steadymark.six import text_type
 
 
 def test_find_doctest_code_with_titles():
-    (u"SteadyMark should find doctest and use the "
+    ("SteadyMark should find doctest and use the "
      "previous header as title")
 
-    md = u"""# test 1
+    md = """# test 1
 a paragraph
 
 ```python
@@ -51,10 +51,10 @@ a paragraph
 
 
 def test_find_python_code_with_titles():
-    (u"SteadyMark should find python code and use the "
+    ("SteadyMark should find python code and use the "
      "previous header as title")
 
-    md = u"""# test 1
+    md = """# test 1
 a paragraph
 
 ```python
@@ -72,9 +72,9 @@ raise ValueError('boom')
 
 
 def test_keeps_scope_from_test_to_test():
-    (u"SteadyMark should accumulate the scope throughout the python code snippets")
+    ("SteadyMark should accumulate the scope throughout the python code snippets")
 
-    md = u"""# test 1
+    md = """# test 1
 a paragraph
 
 ```python

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py26 , py27, py33
+    py26 , py27, py32, py33
 
 [testenv]
 commands =
     make test
 deps =
     nose==1.1.2
-    git+git://github.com/spulec/sure.git@py3k#egg=sure
+    git+git://github.com/grigi/sure.git@master#egg=sure

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ commands =
     make test
 deps =
     nose==1.1.2
-    git+git://github.com/grigi/sure.git@master#egg=sure
+    git+git://github.com/grigi/sure.git@master#egg=sure == 1.2.3


### PR DESCRIPTION
Since importing unicode_literals, u decorator not required on strings from py2.6 and up

I tested this on python 2.7, 3.2 and 3.3

Since both sure and steadymark has cross-dependencies for testing, I had to update both of these at the same time.
I had to change the sample test in README.md, because the u literal isn't valid in Py3.2, but I thought it is ok since as an example it still serves.
